### PR TITLE
Upgrade of multiple calendar implementations to the latest QL versions

### DIFF
--- a/ql/time/calendars/canada.cpp
+++ b/ql/time/calendars/canada.cpp
@@ -62,6 +62,9 @@ namespace QuantLib {
             || (d <= 7 && w == Monday && m == August)
             // first Monday of September (Labor Day)
             || (d <= 7 && w == Monday && m == September)
+            // September 30th, possibly moved to Monday
+            // (National Day for Truth and Reconciliation, since 2021)
+            || (((d == 30 && m == September) || (d <= 2 && m == October && w == Monday)) && y >= 2021)
             // second Monday of October (Thanksgiving Day)
             || (d > 7 && d <= 14 && w == Monday && m == October)
             // November 11th (possibly moved to Monday)

--- a/ql/time/calendars/canada.hpp
+++ b/ql/time/calendars/canada.hpp
@@ -42,6 +42,7 @@ namespace QuantLib {
         <li>Canada Day, July 1st (possibly moved to Monday)</li>
         <li>Provincial Holiday, first Monday of August</li>
         <li>Labour Day, first Monday of September</li>
+        <li>National Day for Truth and Reconciliation, September 30th (possibly moved to Monday)</li>
         <li>Thanksgiving Day, second Monday of October</li>
         <li>Remembrance Day, November 11th (possibly moved to Monday)</li>
         <li>Christmas, December 25th (possibly moved to Monday or Tuesday)</li>

--- a/ql/time/calendars/china.cpp
+++ b/ql/time/calendars/china.cpp
@@ -69,6 +69,7 @@ namespace QuantLib {
             || (y == 2019 && d == 1 && m == January)
             || (y == 2020 && d == 1 && m == January)
             || (y == 2021 && d == 1 && m == January)
+            || (y == 2022 && d == 3 && m == January)
             // Chinese New Year
             || (y == 2004 && d >= 19 && d <= 28 && m == January)
             || (y == 2005 && d >=  7 && d <= 15 && m == February)
@@ -91,6 +92,8 @@ namespace QuantLib {
             || (y == 2019 && d >= 4 && d <= 8 && m == February)
             || (y == 2020 && (d == 24 || (d >= 27 && d <= 31)) && m == January)
             || (y == 2021 && (d == 11 || d == 12 || d == 15 || d == 16 || d == 17) && m == February)
+            || (y == 2022 && ((d == 31 && m == January) ||
+                              (d <= 4 && m == February)))
             // Ching Ming Festival
             || (y <= 2008 && d == 4 && m == April)
             || (y == 2009 && d == 6 && m == April)
@@ -106,6 +109,7 @@ namespace QuantLib {
             || (y == 2019 && d == 5 && m == April)
             || (y == 2020 && d == 6 && m == April)
             || (y == 2021 && d == 5 && m == April)
+            || (y == 2022 && d >= 4 && d <= 5 && m == April)
             // Labor Day
             || (y <= 2007 && d >= 1 && d <= 7 && m == May)
             || (y == 2008 && d >= 1 && d <= 2 && m == May)
@@ -124,6 +128,7 @@ namespace QuantLib {
             || (y == 2019 && d >= 1 && d <=3 && m == May)
             || (y == 2020 && (d == 1 || d == 4 || d == 5) && m == May)
             || (y == 2021 && (d == 3 || d == 4 || d == 5) && m == May)
+            || (y == 2022 && d >= 2 && d <= 4 && m == May)
             // Tuen Ng Festival
             || (y <= 2008 && d == 9 && m == June)
             || (y == 2009 && (d == 28 || d == 29) && m == May)
@@ -139,6 +144,7 @@ namespace QuantLib {
             || (y == 2019 && d == 7 && m == June)
             || (y == 2020 && d >= 25 && d <= 26 && m == June)
             || (y == 2021 && d == 14 && m == June)
+            || (y == 2022 && d == 3 && m == June)
             // Mid-Autumn Festival
             || (y <= 2008 && d == 15 && m == September)
             || (y == 2010 && d >= 22 && d <= 24 && m == September)
@@ -151,6 +157,7 @@ namespace QuantLib {
             || (y == 2018 && d == 24 && m == September)
             || (y == 2019 && d == 13 && m == September)
             || (y == 2021 && (d == 20 || d == 21) && m == September)
+            || (y == 2022 && d == 12 && m == September)
             // National Day
             || (y <= 2007 && d >= 1 && d <= 7 && m == October) 
             || (y == 2008 && ((d >= 29 && m == September) ||
@@ -169,6 +176,7 @@ namespace QuantLib {
             || (y == 2020 && d >= 1 && d <= 2 && m == October)
             || (y == 2020 && d >= 5 && d <= 8 && m == October)
             || (y == 2021 && (d == 1 || d == 4 || d == 5 || d == 6 || d == 7) && m == October)
+            || (y == 2022 && d >= 3 && d <= 7 && m == October)
             // 70th anniversary of the victory of anti-Japaneses war
             || (y == 2015 && d >= 3 && d <= 4 && m == September)
             )
@@ -308,7 +316,15 @@ namespace QuantLib {
             Date(8, May, 2021),
             Date(18, September, 2021),
             Date(26, September, 2021),
-            Date(9, October, 2021)
+            Date(9, October, 2021),
+            // 2022
+            Date(29, January, 2022),
+            Date(30, January, 2022),
+            Date(2, April, 2022),
+            Date(24, April, 2022),
+            Date(7, May, 2022),
+            Date(8, October, 2022),
+            Date(9, October, 2022)
         };
         static const Size n =
             sizeof(working_weekends)/sizeof(working_weekends[0]);

--- a/ql/time/calendars/norway.cpp
+++ b/ql/time/calendars/norway.cpp
@@ -49,7 +49,9 @@ namespace QuantLib {
             // May Day
             || (d == 1  && m == May)
             // National Independence Day
-            || (d == 17  && m == May)
+            || (d == 17 && m == May)
+            // Christmas Eve
+            || (d == 24 && m == December && y >= 2002)
             // Christmas
             || (d == 25 && m == December)
             // Boxing Day
@@ -59,4 +61,3 @@ namespace QuantLib {
     }
 
 }
-

--- a/ql/time/calendars/norway.hpp
+++ b/ql/time/calendars/norway.hpp
@@ -40,7 +40,8 @@ namespace QuantLib {
         <li>Whit(Pentecost) Monday </li>
         <li>New Year's Day, January 1st</li>
         <li>May Day, May 1st</li>
-        <li>National Independence Day, May 17st</li>
+        <li>National Independence Day, May 17th</li>
+        <li>Christmas Eve, December 24th</li>
         <li>Christmas, December 25th</li>
         <li>Boxing Day, December 26th</li>
         </ul>

--- a/ql/time/calendars/unitedkingdom.cpp
+++ b/ql/time/calendars/unitedkingdom.cpp
@@ -23,6 +23,32 @@
 
 namespace QuantLib {
 
+    namespace {
+
+        // common rules
+
+        bool isBankHoliday(Day d, Weekday w, Month m, Year y) {
+            return
+                // first Monday of May (Early May Bank Holiday)
+                // moved to May 8th in 1995 and 2020 for V.E. day
+                (d <= 7 && w == Monday && m == May && y != 1995 && y != 2020)
+                || (d == 8 && m == May && (y == 1995 || y == 2020))
+                // last Monday of May (Spring Bank Holiday)
+                // moved to in 2002, 2012 and 2022 for the Golden, Diamond and Platinum
+                // Jubilee with an additional holiday
+                || (d >= 25 && w == Monday && m == May && y != 2002 && y != 2012 && y != 2022)
+                || ((d == 3 || d == 4) && m == June && y == 2002)
+                || ((d == 4 || d == 5) && m == June && y == 2012)
+                || ((d == 2 || d == 3) && m == June && y == 2022)
+                // last Monday of August (Summer Bank Holiday)
+                || (d >= 25 && w == Monday && m == August)
+                // April 29th, 2011 only (Royal Wedding Bank Holiday)
+                || (d == 29 && m == April && y == 2011)
+                ;
+        }
+
+    }
+
     UnitedKingdom::UnitedKingdom(UnitedKingdom::Market market) {
         // all calendar instances on the same market share the same
         // implementation instance
@@ -61,28 +87,13 @@ namespace QuantLib {
             || (dd == em-3)
             // Easter Monday
             || (dd == em)
-            // first Monday of May (Early May Bank Holiday)
-            // moved to May 8th in 1995 and 2020 for V.E. day
-            || (d <= 7 && w == Monday && m == May && y != 1995 && y != 2020)
-            || (d == 8 && m == May && (y == 1995 || y == 2020))
-            // last Monday of May (Spring Bank Holiday)
-            || (d >= 25 && w == Monday && m == May && y != 2002 && y != 2012)
-            // last Monday of August (Summer Bank Holiday)
-            || (d >= 25 && w == Monday && m == August)
+            || isBankHoliday(d, w, m, y)
             // Christmas (possibly moved to Monday or Tuesday)
             || ((d == 25 || (d == 27 && (w == Monday || w == Tuesday)))
                 && m == December)
             // Boxing Day (possibly moved to Monday or Tuesday)
             || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
                 && m == December)
-            // June 3rd, 2002 only (Golden Jubilee Bank Holiday)
-            // June 4rd, 2002 only (special Spring Bank Holiday)
-            || ((d == 3 || d == 4) && m == June && y == 2002)
-            // April 29th, 2011 only (Royal Wedding Bank Holiday)
-            || (d == 29 && m == April && y == 2011)
-            // June 4th, 2012 only (Diamond Jubilee Bank Holiday)
-            // June 5th, 2012 only (Special Spring Bank Holiday)
-            || ((d == 4 || d == 5) && m == June && y == 2012)
             // December 31st, 1999 only
             || (d == 31 && m == December && y == 1999))
             return false; // NOLINT(readability-simplify-boolean-expr)
@@ -104,28 +115,13 @@ namespace QuantLib {
             || (dd == em-3)
             // Easter Monday
             || (dd == em)
-            // first Monday of May (Early May Bank Holiday)
-            // moved to May 8th in 1995 and 2020 for V.E. day
-            || (d <= 7 && w == Monday && m == May && y != 1995 && y != 2020)
-            || (d == 8 && m == May && (y == 1995 || y == 2020))
-            // last Monday of May (Spring Bank Holiday)
-            || (d >= 25 && w == Monday && m == May && y != 2002 && y != 2012)
-            // last Monday of August (Summer Bank Holiday)
-            || (d >= 25 && w == Monday && m == August)
+            || isBankHoliday(d, w, m, y)
             // Christmas (possibly moved to Monday or Tuesday)
             || ((d == 25 || (d == 27 && (w == Monday || w == Tuesday)))
                 && m == December)
             // Boxing Day (possibly moved to Monday or Tuesday)
             || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
                 && m == December)
-            // June 3rd, 2002 only (Golden Jubilee Bank Holiday)
-            // June 4rd, 2002 only (special Spring Bank Holiday)
-            || ((d == 3 || d == 4) && m == June && y == 2002)
-            // April 29th, 2011 only (Royal Wedding Bank Holiday)
-            || (d == 29 && m == April && y == 2011)
-            // June 4th, 2012 only (Diamond Jubilee Bank Holiday)
-            // June 5th, 2012 only (Special Spring Bank Holiday)
-            || ((d == 4 || d == 5) && m == June && y == 2012)
             // December 31st, 1999 only
             || (d == 31 && m == December && y == 1999))
             return false; // NOLINT(readability-simplify-boolean-expr)
@@ -147,28 +143,13 @@ namespace QuantLib {
             || (dd == em-3)
             // Easter Monday
             || (dd == em)
-            // first Monday of May (Early May Bank Holiday)
-            // moved to May 8th in 1995 and 2020 for V.E. day
-            || (d <= 7 && w == Monday && m == May && y != 1995 && y != 2020)
-            || (d == 8 && m == May && (y == 1995 || y == 2020))
-            // last Monday of May (Spring Bank Holiday)
-            || (d >= 25 && w == Monday && m == May && y != 2002 && y != 2012)
-            // last Monday of August (Summer Bank Holiday)
-            || (d >= 25 && w == Monday && m == August)
+            || isBankHoliday(d, w, m, y)
             // Christmas (possibly moved to Monday or Tuesday)
             || ((d == 25 || (d == 27 && (w == Monday || w == Tuesday)))
                 && m == December)
             // Boxing Day (possibly moved to Monday or Tuesday)
             || ((d == 26 || (d == 28 && (w == Monday || w == Tuesday)))
                 && m == December)
-            // June 3rd, 2002 only (Golden Jubilee Bank Holiday)
-            // June 4rd, 2002 only (special Spring Bank Holiday)
-            || ((d == 3 || d == 4) && m == June && y == 2002)
-            // April 29th, 2011 only (Royal Wedding Bank Holiday)
-            || (d == 29 && m == April && y == 2011)
-            // June 4th, 2012 only (Diamond Jubilee Bank Holiday)
-            // June 5th, 2012 only (Special Spring Bank Holiday)
-            || ((d == 4 || d == 5) && m == June && y == 2012)
             // December 31st, 1999 only
             || (d == 31 && m == December && y == 1999))
             return false; // NOLINT(readability-simplify-boolean-expr)
@@ -176,4 +157,3 @@ namespace QuantLib {
     }
 
 }
-


### PR DESCRIPTION
These four calendars were identified to have been updated in the QL releases following our version 1.22. They were copy pasted from the most recent version, 1.25. 