### PR TITLE
Documentation of SviSmileSection

### DIFF
--- a/ql/experimental/volatility/svismilesection.cpp
+++ b/ql/experimental/volatility/svismilesection.cpp
@@ -38,7 +38,7 @@ namespace QuantLib {
 
 void SviSmileSection::init() {
     QL_REQUIRE(params_.size() == 5,
-               "svi expects 5 parameters (a,b,sigma,rho,s,m) but ("
+               "svi expects 5 parameters (a,b,sigma,rho,m) but ("
                    << params_.size() << ") given");
     detail::checkSviParameters(params_[0], params_[1], params_[2], params_[3],
                                params_[4]);

--- a/ql/experimental/volatility/svismilesection.cpp
+++ b/ql/experimental/volatility/svismilesection.cpp
@@ -44,7 +44,7 @@ void SviSmileSection::init() {
                                params_[4]);
 }
 
-Real SviSmileSection::volatilityImpl(Rate strike) const {
+Volatility SviSmileSection::volatilityImpl(Rate strike) const {
 
     Real k = std::log(std::max(strike, 1E-6) / forward_);
     Real totalVariance = detail::sviTotalVariance(params_[0], params_[1], params_[2],

--- a/ql/experimental/volatility/svismilesection.hpp
+++ b/ql/experimental/volatility/svismilesection.hpp
@@ -37,12 +37,12 @@ class SviSmileSection : public SmileSection {
     //@{
     /*! @param timeToExpiry Time to expiry
         @param forward Forward price corresponding to the expiry date
-        @param sviParameters Expects SVI parameters as a vector composed of a, b, sigma, rho, s, m
+        @param sviParameters Expects SVI parameters as a vector composed of a, b, sigma, rho, m
     */
     SviSmileSection(Time timeToExpiry, Rate forward, std::vector<Real> sviParameters);
     /*! @param d Date of expiry
         @param forward Forward price corresponding to the expiry date
-        @param sviParameters Expects SVI parameters as a vector composed of a, b, sigma, rho, s, m
+        @param sviParameters Expects SVI parameters as a vector composed of a, b, sigma, rho, m
         @param dc Day count method used to compute the time to expiry
     */
     SviSmileSection(const Date& d,

--- a/ql/experimental/volatility/svismilesection.hpp
+++ b/ql/experimental/volatility/svismilesection.hpp
@@ -33,11 +33,23 @@ namespace QuantLib {
 class SviSmileSection : public SmileSection {
 
   public:
+    //! \name Constructors
+    //@{
+    /*! @param timeToExpiry Time to expiry
+        @param forward Forward price corresponding to the expiry date
+        @param sviParameters Expects SVI parameters as a vector composed of a, b, sigma, rho, s, m
+    */
     SviSmileSection(Time timeToExpiry, Rate forward, std::vector<Real> sviParameters);
+    /*! @param d Date of expiry
+        @param forward Forward price corresponding to the expiry date
+        @param sviParameters Expects SVI parameters as a vector composed of a, b, sigma, rho, s, m
+        @param dc Day count method used to compute the time to expiry
+    */
     SviSmileSection(const Date& d,
                     Rate forward,
                     std::vector<Real> sviParameters,
                     const DayCounter& dc = Actual365Fixed());
+    //@}
     Real minStrike() const override { return 0.0; }
     Real maxStrike() const override { return QL_MAX_REAL; }
     Real atmLevel() const override { return forward_; }


### PR DESCRIPTION
I recently added some docstrings to the `SviSmileSection` ctors, mostly for my own understanding, but I thought they might help others too. I also noticed that the error message incorrectly included a 6th argument (the 's') and that the return type in the definition of `volImpl()` didn't entirely match it's declaration, both of which I adjusted.

ORE won't be affected by this as we don't use SVI at this time.